### PR TITLE
Corrects the definition of the "ID" column.

### DIFF
--- a/E-Commerce Shipping Data.ipynb
+++ b/E-Commerce Shipping Data.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "### Key Variables\n",
     "\n",
-    "- **ID**: ID Number of Customers.\n",
+    "- **ID**: Index column.\n",
     "- **Warehouse Block**: Section of the warehouse (A, B, C, D, E) where the product is stored.\n",
     "- **Mode of Shipment**: Shipping method (e.g., Ship, Flight, Road).\n",
     "- **Customer Care Calls**: The number of calls made by customers to inquire about the status of their shipments.\n",


### PR DESCRIPTION
Defining the "ID" column as the index column is more meaningful than defining it as the ID Number of Customers.

## Summary by Sourcery

Documentation:
- Update the definition of the 'ID' column in the documentation to indicate it is an index column rather than an ID number of customers.